### PR TITLE
feat: Update quick path cards on homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import BarkCloth from "./pages/materials/BarkCloth";
 import Mukasa from "./pages/names/Mukasa";
 import Luwombo from "./pages/food/Luwombo";
 import KintuAndNambi from "./pages/stories/KintuAndNambi";
+import WhyBoda from "./pages/stories/WhyBoda";
+import Stories from "./pages/Stories";
 import Experiences from "./pages/Experiences";
 import Blog from "./pages/Blog";
 import EtiquetteStarter from "./pages/blog/EtiquetteStarter";
@@ -49,6 +51,8 @@ const App = () => (
               <Route path="/names/mukasa" element={<Mukasa />} />
               <Route path="/food/luwombo" element={<Luwombo />} />
               <Route path="/stories/kintu-and-nambi" element={<KintuAndNambi />} />
+              <Route path="/stories/why-boda" element={<WhyBoda />} />
+              <Route path="/stories" element={<Stories />} />
               <Route path="/experiences" element={<Experiences />} />
               <Route path="/blog" element={<Blog />} />
               <Route path="/blog/etiquette-starter" element={<EtiquetteStarter />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,19 +1,26 @@
 import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, X, Search } from "lucide-react";
+import { Menu, X, Search, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const location = useLocation();
 
-  const navigation = [
-    { name: "Home", href: "/" },
+  const cultureLinks = [
     { name: "Guides", href: "/tribes" },
     { name: "Etiquette", href: "/blog/etiquette-starter" },
-    { name: "Stories", href: "/stories/kintu-and-nambi" },
     { name: "Food", href: "/food/luwombo" },
-    { name: "Book", href: "/book" },
+  ];
+
+  const navigation = [
+    { name: "Stories", href: "/stories" },
   ];
 
   const isActive = (path: string) => location.pathname === path;
@@ -35,22 +42,33 @@ const Header = () => {
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:block">
-            <div className="ml-10 flex items-baseline space-x-8">
-              {navigation.map((item) => (
-                <Link
-                  key={item.name}
-                  to={item.href}
-                  className={`px-3 py-2 text-sm font-medium transition-colors hover:text-accent boda-underline ${
-                    isActive(item.href)
-                      ? "text-foreground"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  {item.name}
-                </Link>
-              ))}
-            </div>
+          <div className="hidden md:flex items-center space-x-8">
+            <DropdownMenu>
+              <DropdownMenuTrigger className="flex items-center text-sm font-medium text-muted-foreground hover:text-accent transition-colors">
+                Culture <ChevronDown className="h-4 w-4 ml-1" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                {cultureLinks.map((item) => (
+                  <DropdownMenuItem key={item.name} asChild>
+                    <Link to={item.href}>{item.name}</Link>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {navigation.map((item) => (
+              <Link
+                key={item.name}
+                to={item.href}
+                className={`px-3 py-2 text-sm font-medium transition-colors hover:text-accent boda-underline ${
+                  isActive(item.href)
+                    ? "text-foreground"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {item.name}
+              </Link>
+            ))}
           </div>
 
           {/* Desktop Actions */}
@@ -59,7 +77,7 @@ const Header = () => {
               <Search className="h-4 w-4" />
             </Button>
             <Link to="/preorder">
-              <Button className="btn-primary">Pre-order</Button>
+              <Button className="btn-primary">Preorder</Button>
             </Link>
           </div>
 
@@ -82,6 +100,19 @@ const Header = () => {
         {isMenuOpen && (
           <div className="md:hidden">
             <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 border-t border-border">
+              <DropdownMenu>
+                <DropdownMenuTrigger className="flex items-center justify-between w-full px-3 py-2 text-base font-medium text-muted-foreground rounded-md hover:text-accent hover:bg-muted">
+                  Culture <ChevronDown className="h-4 w-4 ml-1" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  {cultureLinks.map((item) => (
+                    <DropdownMenuItem key={item.name} asChild>
+                      <Link to={item.href} onClick={() => setIsMenuOpen(false)}>{item.name}</Link>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
               {navigation.map((item) => (
                 <Link
                   key={item.name}
@@ -98,7 +129,7 @@ const Header = () => {
               ))}
               <div className="mt-4 pt-4 border-t border-border">
                 <Link to="/preorder" onClick={() => setIsMenuOpen(false)}>
-                  <Button className="w-full btn-primary">Pre-order</Button>
+                  <Button className="w-full btn-primary">Preorder</Button>
                 </Link>
               </div>
             </div>
@@ -116,16 +147,12 @@ const Header = () => {
           </Link>
           <Link to="/tribes" className="flex flex-col items-center justify-center">
             <span className={`text-xs ${isActive("/tribes") ? "text-accent" : "text-muted-foreground"}`}>
-              Guides
+              Culture
             </span>
           </Link>
-          <button className="flex flex-col items-center justify-center">
-            <Search className="h-5 w-5 text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">Search</span>
-          </button>
-          <Link to="/join" className="flex flex-col items-center justify-center">
-            <span className={`text-xs ${isActive("/join") ? "text-accent" : "text-muted-foreground"}`}>
-              Join
+          <Link to="/preorder" className="flex flex-col items-center justify-center">
+            <span className={`text-xs ${isActive("/preorder") ? "text-accent" : "text-muted-foreground"}`}>
+              Preorder
             </span>
           </Link>
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,9 +7,9 @@ import heroBodaRider from "@/assets/hero-boda-rider.jpg";
 
 const Home = () => {
   const quickPathCards = [
+    { title: "Why Boda?", description: "The origin story of the boda-boda", href: "/stories/why-boda" },
     { title: "Before You Go", description: "Essential preparation tips", href: "/blog/etiquette-starter" },
     { title: "Greetings & Respect", description: "Cultural etiquette guide", href: "/blog/etiquette-starter" },
-    { title: "How to Ride a Boda", description: "Transportation basics", href: "/experiences" },
     { title: "Food You Must Try", description: "Culinary highlights", href: "/food/luwombo" },
     { title: "Stories in 60s", description: "Quick cultural insights", href: "/stories/kintu-and-nambi" },
     { title: "Packing & Dress", description: "What to wear and bring", href: "/attire/gomesi" },
@@ -53,7 +53,7 @@ const Home = () => {
               <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-8">
                 <Link to="/tribes">
                   <BodaButton variant="secondary" size="lg">
-                    Explore Tribes
+                    Explore Culture
                   </BodaButton>
                 </Link>
                 <BodaButton variant="ghost" size="lg" className="flex items-center gap-2">

--- a/src/pages/Stories.tsx
+++ b/src/pages/Stories.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+
+const storiesData = [
+  {
+    title: "Kintu and Nambi",
+    description: "The creation story of the Baganda people, a foundational myth of Uganda.",
+    date: "2024-01-01",
+    href: "/stories/kintu-and-nambi",
+    image: "/src/assets/kintu-nambi-story.jpg",
+  },
+  {
+    title: "Why Boda?",
+    description: "The origin story of the boda-boda, from border-crossing bicycles to urban icons.",
+    date: "2024-01-02",
+    href: "/stories/why-boda",
+    image: "/src/assets/hero-boda-rider.jpg",
+  },
+];
+
+const StoriesPage = () => {
+  const [stories, setStories] = useState(storiesData);
+  const [sortOrder, setSortOrder] = useState<"date" | "name">("date");
+
+  const sortStories = (criteria: "date" | "name") => {
+    const sortedStories = [...storiesData].sort((a, b) => {
+      if (criteria === "name") {
+        return a.title.localeCompare(b.title);
+      }
+      // Default to reverse chronological order
+      return new Date(b.date).getTime() - new Date(a.date).getTime();
+    });
+    setStories(sortedStories);
+    setSortOrder(criteria);
+  };
+
+  return (
+    <div className="min-h-screen py-12">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold text-foreground mb-4">
+            Stories from Uganda
+          </h1>
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+            A collection of myths, legends, and modern tales that shape the cultural landscape of the Pearl of Africa.
+          </p>
+        </div>
+
+        <div className="flex justify-center gap-4 mb-8">
+          <Button
+            variant={sortOrder === "date" ? "primary" : "secondary"}
+            onClick={() => sortStories("date")}
+          >
+            Sort by Latest
+          </Button>
+          <Button
+            variant={sortOrder === "name" ? "primary" : "secondary"}
+            onClick={() => sortStories("name")}
+          >
+            Sort by Name
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {stories.map((story, index) => (
+            <Link key={index} to={story.href} className="group">
+              <Card className="boda-card h-full overflow-hidden">
+                <div className="aspect-video bg-muted overflow-hidden">
+                  <img src={story.image} alt={story.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" />
+                </div>
+                <CardHeader>
+                  <CardTitle className="text-xl group-hover:text-accent transition-colors">
+                    {story.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-muted-foreground mb-4">
+                    {story.description}
+                  </p>
+                  <div className="flex items-center text-accent text-sm font-medium">
+                    Read more <ArrowRight className="h-4 w-4 ml-2 group-hover:translate-x-1 transition-transform" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StoriesPage;

--- a/src/pages/stories/WhyBoda.tsx
+++ b/src/pages/stories/WhyBoda.tsx
@@ -1,0 +1,101 @@
+import { Link } from "react-router-dom";
+import { BodaButton } from "@/components/ui/boda-button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft } from "lucide-react";
+
+const WhyBoda = () => {
+  return (
+    <div className="min-h-screen py-12">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-8">
+            <Link to="/stories" className="flex items-center text-muted-foreground hover:text-accent transition-colors">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Stories
+            </Link>
+          </div>
+
+          <h1 className="text-4xl font-bold text-foreground mb-4">Why Boda?</h1>
+          <p className="text-xl text-muted-foreground mb-12">The Boda Boda Name: A Timeline</p>
+
+          <div className="space-y-12">
+            <Card className="boda-card">
+              <CardHeader>
+                <CardTitle className="text-2xl">1960s–1980s: The "Border-to-Border" Origin</CardTitle>
+              </CardHeader>
+              <CardContent className="prose prose-lg max-w-none">
+                <p>
+                  The story begins not in a city, but on the dusty frontier between Kenya and Uganda. To cross the half-mile of "no-man's land" between official border posts in a car was a nightmare of paperwork and delays. Local entrepreneurs saw a gap and filled it, using sturdy bicycles to ferry people and goods across the divide, bypassing the bureaucracy. Their call to customers was simple and direct:
+                </p>
+                <blockquote>"border, border!"</blockquote>
+                <p>
+                  Street slang and daily repetition soon compressed this into the single, unforgettable name:
+                </p>
+                <blockquote>"boda-boda".</blockquote>
+              </CardContent>
+            </Card>
+
+            <Card className="boda-card">
+              <CardHeader>
+                <CardTitle className="text-2xl">Late 1980s–Early 1990s: From a Service to an Identity</CardTitle>
+              </CardHeader>
+              <CardContent className="prose prose-lg max-w-none">
+                <p>
+                  The name quickly became more than a description; it became a "proud badge for being a fast expert rider". "Boda-boda" was now synonymous with speed, agility, and the ingenuity to connect people and places where formal systems couldn't.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card className="boda-card">
+              <CardHeader>
+                <CardTitle className="text-2xl">Mid-1990s: The Motorcycle Adoption</CardTitle>
+              </CardHeader>
+              <CardContent className="prose prose-lg max-w-none">
+                <p>
+                  When cheaper, more powerful motorcycles arrived, they were the perfect upgrade. They naturally inherited the "boda-boda" name and the maverick spirit that came with it, amplifying its ability to connect.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card className="boda-card">
+              <CardHeader>
+                <CardTitle className="text-2xl">2000s–Today: The Urban Definition</CardTitle>
+              </CardHeader>
+              <CardContent className="prose prose-lg max-w-none">
+                <p>
+                  The boda-boda migrated from the border to the heart of East Africa's cities. In the gridlocked streets of Kampala, it became the essential urban connector—the unofficial circulatory system that keeps the city alive. Today, the name is a direct link to this rich history of movement and connection.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="mt-16 text-center bg-secondary rounded-lg p-12">
+            <h2 className="text-3xl font-bold text-foreground mb-4">
+              At its heart, the boda-boda has always been about one thing: connection.
+            </h2>
+            <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+              It connects people to places, goods to markets, and ambition to opportunity. It’s the thread that weaves through the urban and rural landscapes of Uganda. That same spirit is the driving force behind our name, Boda.
+            </p>
+            <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+              Our mission is to Discover Uganda Like Never Before. Just like boda-bodas connect people across Uganda, we connect you to the rich tapestry of traditions, stories, and heritage that make this country extraordinary. We are your ride into the heart of the Pearl of Africa.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link to="/tribes">
+                <BodaButton variant="primary" size="lg">
+                  Explore Culture
+                </BodaButton>
+              </Link>
+              <Link to="/preorder">
+                <BodaButton variant="secondary" size="lg">
+                  Preorder the Book
+                </BodaButton>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WhyBoda;


### PR DESCRIPTION
This commit updates the 'Quick Path' cards on the homepage to include a link to the new 'Why Boda?' story and remove the 'How to Ride a Boda' card.

- Adds a new card for 'Why Boda?' as the first item in the list.
- Removes the 'How to Ride a Boda' card.