### PR TITLE
Update home page quick path

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,9 +7,9 @@ import heroBodaRider from "@/assets/hero-boda-rider.jpg";
 
 const Home = () => {
   const quickPathCards = [
+    { title: "Why the name Boda?", description: "The origin story of the boda-boda, from border-crossing bicycles to urban icons.", href: "/stories/why-boda" },
     { title: "Before You Go", description: "Essential preparation tips", href: "/blog/etiquette-starter" },
     { title: "Greetings & Respect", description: "Cultural etiquette guide", href: "/blog/etiquette-starter" },
-    { title: "How to Ride a Boda", description: "Transportation basics", href: "/experiences" },
     { title: "Food You Must Try", description: "Culinary highlights", href: "/food/luwombo" },
     { title: "Stories in 60s", description: "Quick cultural insights", href: "/stories/kintu-and-nambi" },
     { title: "Packing & Dress", description: "What to wear and bring", href: "/attire/gomesi" },


### PR DESCRIPTION
- Removes "How to Ride a Boda" from the quick path section on the home page.
- Adds "Why the name Boda?" as the first item in the quick path section.