### PR TITLE
feat: Update story and blog content

### DIFF
--- a/src/data/stories.json
+++ b/src/data/stories.json
@@ -7,13 +7,6 @@
     "image": "/src/assets/kintu-nambi-story.jpg"
   },
   {
-    "title": "Why the name Boda?",
-    "description": "The origin story of the boda-boda, from border-crossing bicycles to urban icons.",
-    "date": "2024-01-02",
-    "href": "/stories/why-boda",
-    "image": "/src/assets/hero-boda-rider.jpg"
-  },
-  {
     "title": "The Parting of Gipir and Labong",
     "description": "The classic version, centered on the bead and the spear, that explains the origin of the Acholi and Alur peoples.",
     "date": "2024-01-03",

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -17,13 +17,6 @@ const articles = [
     readTime: "5 min read",
     href: "/blog/why-boda"
   },
-  {
-    title: "The Legend of Kintu and Nambi",
-    description: "Buganda's foundational creation story and its cultural significance",
-    category: "Traditional Stories",
-    readTime: "12 min read",
-    href: "/stories/kintu-and-nambi"
-  }
 ];
 
 const categories = ["All Stories", "Travel Tips", "Cultural Guides", "Food & Recipes", "Traditional Crafts", "Languages", "Cultural Stories", "Traditional Stories"];


### PR DESCRIPTION
- Moves "Why Boda" from the stories section to the blog section by removing the incorrect data entry from `stories.json`. The story was already present in the blog data and component.
- Removes "Kintu and Nambi" from the blog page listing, while keeping it in the stories section as requested.

This addresses the user's request to clean up the story and blog listings and remove duplication.