### PR TITLE
feat: Standardize 'Coming Soon' and 404 CTAs

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -6,7 +6,7 @@ import { Home, Search, Book, Users, ArrowRight } from "lucide-react";
 const NotFound = () => {
   const quickLinks = [
     { title: "Explore Tribes", description: "Discover Uganda's cultural diversity", href: "/tribes", icon: Users },
-    { title: "Boda Book Series", description: "Pre-order the complete guide", href: "/book", icon: Book },
+    { title: "Boda Book Series", description: "Pre-order the complete guide", href: "/preorder", icon: Book },
     { title: "Cultural Stories", description: "Read traditional legends", href: "/stories/kintu-and-nambi", icon: Book },
     { title: "Join Our Community", description: "Get cultural insights weekly", href: "/join", icon: Users }
   ];

--- a/src/pages/stories/KintuAndNambi.tsx
+++ b/src/pages/stories/KintuAndNambi.tsx
@@ -1,6 +1,6 @@
 import storyImage from "@/assets/kintu-nambi-story.jpg";
 import { BodaButton } from "@/components/ui/boda-button";
-import StoryExcerptCTA from "@/components/StoryExcerptCTA";
+import { Link } from "react-router-dom";
 
 const KintuAndNambi = () => {
   return (
@@ -31,16 +31,20 @@ const KintuAndNambi = () => {
           </div>
 
           {/* Story Content */}
-          <div className="space-y-12">
-            <div className="prose prose-lg max-w-none text-center">
-              <h2 className="text-3xl font-bold text-foreground mb-4">
-                Coming Soon
-              </h2>
-              <p className="text-muted-foreground leading-relaxed">
-                The full story of Kintu and Nambi is being prepared and will be available here soon. Thank you for your patience.
-              </p>
-            </div>
-            <StoryExcerptCTA />
+          <div className="text-center bg-secondary rounded-lg p-8 my-12">
+            <h2 className="text-3xl font-bold text-foreground mb-4">
+              Content Coming Soon
+            </h2>
+            <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+              This section is currently under development. The complete, unabridged
+              content will be available in the Boda Book Series. Pre-order now to
+              be the first to get access.
+            </p>
+            <Link to="/preorder">
+              <BodaButton variant="primary" size="lg">
+                Pre-order the Boda Book Series
+              </BodaButton>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/pages/tribes/BagandaTribe.tsx
+++ b/src/pages/tribes/BagandaTribe.tsx
@@ -217,11 +217,20 @@ const BagandaTribe = () => {
             </TabsContent>
 
             <TabsContent value="traditions">
-              <div className="space-y-6">
-                <h3 className="text-2xl font-semibold text-foreground">Coming Soon</h3>
-                <p className="text-muted-foreground">
-                  Detailed information about Baganda ceremonies, rituals, and traditional practices will be available soon.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
 
@@ -251,11 +260,20 @@ const BagandaTribe = () => {
             </TabsContent>
 
             <TabsContent value="places">
-              <div className="space-y-6">
-                <h3 className="text-2xl font-semibold text-foreground">Coming Soon</h3>
-                <p className="text-muted-foreground">
-                  Information about important Baganda historical sites, palaces, and cultural landmarks.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
           </Tabs>

--- a/src/pages/tribes/KaramojongTribe.tsx
+++ b/src/pages/tribes/KaramojongTribe.tsx
@@ -57,51 +57,105 @@ const KaramojongTribe = () => {
             </TabsList>
 
             <TabsContent value="overview">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about the Karamojong tribe is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="clothing">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Karamojong clothing is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="food">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Karamojong food is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="traditions">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Karamojong traditions is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="names">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Karamojong names is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="places">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Karamojong places is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
           </Tabs>

--- a/src/pages/tribes/LangoTribe.tsx
+++ b/src/pages/tribes/LangoTribe.tsx
@@ -57,51 +57,105 @@ const LangoTribe = () => {
             </TabsList>
 
             <TabsContent value="overview">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about the Lango tribe is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="clothing">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Lango clothing is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="food">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Lango food is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="traditions">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Lango traditions is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="names">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Lango names is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
             <TabsContent value="places">
-              <div className="text-center py-16">
-                <h3 className="text-2xl font-semibold text-foreground">Content Coming Soon</h3>
-                <p className="text-muted-foreground mt-2">
-                  Detailed information about Lango places is being prepared.
+              <div className="text-center bg-secondary rounded-lg p-8 my-12">
+                <h2 className="text-3xl font-bold text-foreground mb-4">
+                  Content Coming Soon
+                </h2>
+                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                  This section is currently under development. The complete, unabridged
+                  content will be available in the Boda Book Series. Pre-order now to
+                  be the first to get access.
                 </p>
+                <Link to="/preorder">
+                  <BodaButton variant="primary" size="lg">
+                    Pre-order the Boda Book Series
+                  </BodaButton>
+                </Link>
               </div>
             </TabsContent>
           </Tabs>


### PR DESCRIPTION
This commit standardizes the "Coming Soon" messages across the application to provide a consistent user experience and a clear call-to-action.

Key changes:
- Replaced all instances of "Coming Soon" with a standardized message and a button that links directly to the `/preorder` page. This encourages users to pre-order the Boda Book Series.
- Updated the 404 page to ensure the pre-order link also directs to `/preorder` for consistency.
- The following pages were updated:
  - `src/pages/stories/KintuAndNambi.tsx`
  - `src/pages/tribes/BagandaTribe.tsx`
  - `src/pages/tribes/KaramojongTribe.tsx`
  - `src/pages/tribes/LangoTribe.tsx`
  - `src/pages/NotFound.tsx`