### PR TITLE
feat: Allow multiple pre-orders for the same book

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import Home from "./pages/Home";
 import Preorder from "./pages/Preorder";
+import PreordersPage from "./pages/Preorders";
 import Book from "./pages/Book";
 import Tribes from "./pages/Tribes";
 import BagandaTribe from "./pages/tribes/BagandaTribe";
@@ -56,6 +57,7 @@ const App = () => (
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/preorder" element={<Preorder />} />
+              <Route path="/preorders" element={<PreordersPage />} />
               <Route path="/book" element={<Book />} />
               <Route path="/tribes" element={<Tribes />} />
               <Route path="/tribes/baganda" element={<BagandaTribe />} />

--- a/src/components/PreorderModule.tsx
+++ b/src/components/PreorderModule.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { BodaButton } from "@/components/ui/boda-button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -10,23 +10,57 @@ const PreorderModule = () => {
   const [edition, setEdition] = useState("");
   const { toast } = useToast();
 
+  useEffect(() => {
+    const storedEmail = localStorage.getItem("preorderEmail");
+    if (storedEmail) {
+      setEmail(storedEmail);
+    }
+  }, []);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email) {
+    if (!email || !edition) {
       toast({
-        title: "Email required",
-        description: "Please enter your email address to reserve your copy.",
+        title: "Missing information",
+        description: "Please enter your email and select an edition.",
         variant: "destructive",
       });
       return;
     }
     
-    // Simulate form submission
+    localStorage.setItem("preorderEmail", email);
+
+    const newPreorder = {
+      email,
+      edition,
+      id: `${new Date().toISOString()}-${edition}`,
+      date: new Date().toISOString(),
+    };
+
+    const existingPreorders = JSON.parse(localStorage.getItem("preorders") || "[]");
+
+    const isDuplicate = existingPreorders.some(
+      (order: any) => order.email === newPreorder.email && order.edition === newPreorder.edition
+    );
+
+    if (isDuplicate) {
+      toast({
+        title: "Already Pre-ordered",
+        description: "You have already pre-ordered this edition.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const updatedPreorders = [...existingPreorders, newPreorder];
+    localStorage.setItem("preorders", JSON.stringify(updatedPreorders));
+
     toast({
       title: "Reserved successfully!",
       description: "You'll receive launch updates and early access.",
     });
-    setEmail("");
+
+    // Don't clear email, but clear edition
     setEdition("");
   };
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -38,6 +38,7 @@ const Header = () => {
     { name: "Stories", href: "/stories" },
     { name: "Blog", href: "/blog" },
     { name: "Experiences", href: "/experiences" },
+    { name: "My Pre-orders", href: "/preorders" },
     { name: "About", href: "/about" },
   ];
 

--- a/src/pages/Preorders.tsx
+++ b/src/pages/Preorders.tsx
@@ -1,0 +1,130 @@
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { BodaButton } from "@/components/ui/boda-button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+
+const PreordersPage = () => {
+  const [preorders, setPreorders] = useState<any[]>([]);
+  const [filteredPreorders, setFilteredPreorders] = useState<any[]>([]);
+  const [emailFilter, setEmailFilter] = useState("");
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const storedPreorders = JSON.parse(localStorage.getItem("preorders") || "[]");
+    setPreorders(storedPreorders);
+    setFilteredPreorders(storedPreorders);
+
+    const storedEmail = localStorage.getItem("preorderEmail");
+    if (storedEmail) {
+      setEmailFilter(storedEmail);
+      setFilteredPreorders(
+        storedPreorders.filter((order: any) => order.email === storedEmail)
+      );
+    }
+  }, []);
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const email = e.target.value;
+    setEmailFilter(email);
+    if (email) {
+      setFilteredPreorders(
+        preorders.filter((order) =>
+          order.email.toLowerCase().includes(email.toLowerCase())
+        )
+      );
+    } else {
+      setFilteredPreorders(preorders);
+    }
+  };
+
+  const handleClearHistory = () => {
+    localStorage.removeItem("preorders");
+    localStorage.removeItem("preorderEmail");
+    setPreorders([]);
+    setFilteredPreorders([]);
+    setEmailFilter("");
+    toast({
+      title: "History Cleared",
+      description: "Your pre-order history has been cleared.",
+    });
+  };
+
+  return (
+    <div className="min-h-screen py-12">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-12">
+            <h1 className="text-4xl font-bold text-foreground mb-4">
+              My Pre-orders
+            </h1>
+            <p className="text-xl text-muted-foreground">
+              View and manage your pre-ordered editions of the Boda Book Series.
+            </p>
+          </div>
+
+          <Card className="boda-card">
+            <CardHeader>
+              <CardTitle>Your Pre-order History</CardTitle>
+              <div className="flex items-center space-x-4 pt-4">
+                <Input
+                  placeholder="Filter by email..."
+                  value={emailFilter}
+                  onChange={handleFilterChange}
+                  className="max-w-sm boda-input"
+                />
+                <BodaButton variant="destructive" onClick={handleClearHistory}>
+                  Clear History
+                </BodaButton>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Edition</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Country</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredPreorders.length > 0 ? (
+                    filteredPreorders.map((order) => (
+                      <TableRow key={order.id}>
+                        <TableCell>
+                          {new Date(order.date).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell>{order.email}</TableCell>
+                        <TableCell>{order.edition}</TableCell>
+                        <TableCell>{order.name || "N/A"}</TableCell>
+                        <TableCell>{order.country || "N/A"}</TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center">
+                        No pre-orders found.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PreordersPage;


### PR DESCRIPTION
This commit updates the pre-order functionality to allow users to create multiple pre-orders for the same book, as well as for multiple different books.

The changes are implemented as follows:

- Pre-order data is now saved to the browser's local storage.
- A new page, `/preorders`, has been created to display a user's pre-order history.
- The header has been updated with a link to the new "My Pre-orders" page.
- The pre-order form now pre-fills the user's email address if they have pre-ordered before.
- A check has been added to prevent duplicate pre-orders for the same edition.