### PR TITLE
feat: Remove 'About' link from header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -41,7 +41,6 @@ const Header = () => {
 
   const navigation = [
     { name: "Experiences", href: "/experiences" },
-    { name: "About", href: "/about" },
   ];
 
   const isActive = (path: string) => location.pathname === path;


### PR DESCRIPTION
Removes the 'About' link from the main navigation header. The About page remains accessible at /about, and links in the footer and other pages are unaffected.